### PR TITLE
Mitigate a potential race in initialize!

### DIFF
--- a/src/com/keminglabs/zmq_async/core.clj
+++ b/src/com/keminglabs/zmq_async/core.clj
@@ -326,11 +326,13 @@ Does nothing if zmq-thread is already started."
   (let [{:keys [addr ^ZMQ$Socket sock-server ^ZMQ$Socket sock-client
                 ^Thread zmq-thread ^Thread async-thread]} context]
     (when-not (.isAlive zmq-thread)
-      (.bind sock-server addr)
-      (.start zmq-thread)
+      (locking zmq-thread
+        (when-not (.isAlive zmq-thread)
+          (.bind sock-server addr)
+          (.start zmq-thread)
 
-      (.connect sock-client addr)
-      (.start async-thread)))
+          (.connect sock-client addr)
+          (.start async-thread)))))
   nil)
 
 (def ^:private automagic-context


### PR DESCRIPTION
There's a potential race in `initialize!` that I've run in to that's caused `EADDRINUSE` errors. Test/lock/test mitigates. 
